### PR TITLE
Update build for new jenkins server

### DIFF
--- a/installer/adjustSUFs.js
+++ b/installer/adjustSUFs.js
@@ -1,9 +1,9 @@
 const fs = require('fs');
-const installerWorkspace = process.env.installerWorkspace;
+const installerWorkspace = process.env.WORKSPACE;
 const installerFolder = `${installerWorkspace}\\installer`;
 const files = fs.readdirSync(installerFolder);
 
-files.forEach(fileName => {
+files.forEach((fileName) => {
   if (fileName.endsWith('.suf')) {
     const sufFileName = `${installerFolder}\\${fileName}`;
     const fileContent = fs.readFileSync(sufFileName, 'utf8');
@@ -16,11 +16,7 @@ function replaceVersion(fileContent) {
 }
 
 function adjustOutputFolder(fileContent) {
-  return fileContent.replace(
-    /~~installer-folder~~/g,
-    `${installerFolder}`
-  ).replace(
-    /~~release-folder~~/g,
-    `${installerWorkspace}\\release`
-  );
+  return fileContent
+    .replace(/~~installer-folder~~/g, `${installerFolder}`)
+    .replace(/~~release-folder~~/g, `${installerWorkspace}\\release`);
 }

--- a/installer/adjustSUFs.js
+++ b/installer/adjustSUFs.js
@@ -18,5 +18,5 @@ function replaceVersion(fileContent) {
 function adjustOutputFolder(fileContent) {
   return fileContent
     .replace(/~~installer-folder~~/g, `${installerFolder}`)
-    .replace(/~~release-folder~~/g, `${installerWorkspace}\\release`);
+    .replace(/~~release-folder~~/g, `c:\\temp\\release`);
 }

--- a/installer/build-installers.bat
+++ b/installer/build-installers.bat
@@ -4,9 +4,6 @@
 
 @ECHO.
 @ECHO ##### Adjusting SUFS #####
-@ECHO "Current working directory: %WORKSPACE%"
-@ECHO "Current working dir: %workspace_dir%"
-// SET installerWorkspace=C:\Users\Administrator\AppData\Local\Jenkins\.jenkins\workspace\mSupply Dashboard Installers
 FOR /F "delims=*" %%i in ('more version.txt') do SET versionTag=%%i
 @ECHO "current tag = %versionTag%"
 

--- a/installer/build-installers.bat
+++ b/installer/build-installers.bat
@@ -4,15 +4,17 @@
 
 @ECHO.
 @ECHO ##### Adjusting SUFS #####
-SET installerWorkspace=C:\Program Files (x86)\Jenkins\jobs\mSupply Dashboard Installers\workspace
+@ECHO "Current working directory: %WORKSPACE%"
+@ECHO "Current working dir: %workspace_dir%"
+// SET installerWorkspace=C:\Users\Administrator\AppData\Local\Jenkins\.jenkins\workspace\mSupply Dashboard Installers
 FOR /F "delims=*" %%i in ('more version.txt') do SET versionTag=%%i
 @ECHO "current tag = %versionTag%"
 
 cd installer
-node "%installerWorkspace%\installer\adjustSUFs.js"
+node "%WORKSPACE%\installer\adjustSUFs.js"
 cd ..
 
 @ECHO.
 @ECHO ##### Creating installers #####
-start "" /wait "C:\Program Files (x86)\Setup Factory 9\SUFDesign.exe" /BUILD /LOG:installer\setup-factory.log "%installerWorkspace%\installer\dashboard.suf"
-start "" /wait "C:\Program Files (x86)\Setup Factory 9\SUFDesign.exe" /BUILD /LOG:installer\setup-factory.log "%installerWorkspace%\installer\dashboard-upgrade.suf"
+start "" /wait "C:\Program Files (x86)\Setup Factory 9\SUFDesign.exe" /BUILD /LOG:installer\setup-factory.log "%WORKSPACE%\installer\dashboard.suf"
+start "" /wait "C:\Program Files (x86)\Setup Factory 9\SUFDesign.exe" /BUILD /LOG:installer\setup-factory.log "%WORKSPACE%\installer\dashboard-upgrade.suf"

--- a/installer/build-installers.bat
+++ b/installer/build-installers.bat
@@ -1,6 +1,7 @@
 @ECHO ##### Removing previous installers #####
 @del /q installer\dashboard-setup-*.exe
 @del /q installer\dashboard-upgrade-*.exe
+@del /q c:\temp\release
 
 @ECHO.
 @ECHO ##### Adjusting SUFS #####
@@ -10,6 +11,11 @@ FOR /F "delims=*" %%i in ('more version.txt') do SET versionTag=%%i
 cd installer
 node "%WORKSPACE%\installer\adjustSUFs.js"
 cd ..
+
+REM required as setup factory crashes when a file path is too long
+REM and the jenkins workspace is a very long path
+@ECHO ##### Copying build files #####
+@move /Y "%WORKSPACE%\release" "c:\temp\release"
 
 @ECHO.
 @ECHO ##### Creating installers #####


### PR DESCRIPTION
## Description
<!--- Briefly describe your changes -->
Makes changes needed to get the build working on the new jenkins server

* update paths
* move working files to a shorter base path

that last change is necessary because the new workspace path is very long. Setup factory was crashing part way through the build and the resolution was to reduce the file path length

